### PR TITLE
VAP-333 remove label for attr

### DIFF
--- a/docs/mockups/background.html
+++ b/docs/mockups/background.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.05" name="version"/>
+  <meta content="2019.09.11" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Background Form
@@ -161,7 +161,7 @@
     </h3>
     <div class="row">
      <div class="col-sm-6 col-md-4">
-      <label class="control-label" for="sbahao-i">
+      <label class="control-label">
        Have you ever worked in any of the following?
       </label>
      </div>
@@ -254,7 +254,7 @@
     <hr class="visible-xs-block visible-sm-block"/>
     <div class="row">
      <div class="col-sm-6 col-md-4 col-lg-4">
-      <label for="sblcs-n">
+      <label>
        Have you experienced any symptoms indicative of lung cancer?
       </label>
      </div>
@@ -358,9 +358,9 @@
     <hr class="visible-xs-block visible-sm-block"/>
     <div class="row">
      <div class="col-sm-6 col-md-4 col-lg-4">
-      <label class="control-label" for="sbahpft-n">
-       Have you had a pulmonary function test within the last
-                        five years?
+      <label class="control-label">
+       Have you had a pulmonary function test within the last five
+                        years?
       </label>
      </div>
      <div class="col-sm-6 col-md-3 col-lg-2">
@@ -421,7 +421,7 @@
     <hr class="visible-xs-block visible-sm-block"/>
     <div class="row">
      <div class="col-sm-6 col-md-4 col-lg-4">
-      <label class="control-label" for="sbscs-n">
+      <label class="control-label">
        Have you been provided with smoking cessation
                         services?
       </label>
@@ -525,7 +525,7 @@
       <div class="row">
        <div class="col-md-12">
         <div class="form-group">
-         <label for="sbscs5a-n">
+         <label>
           Have you been counseled on the 5 A’s (Ask, Assess, Advise,
                                     Assist, Arrange)?
          </label>
@@ -544,7 +544,7 @@
       <div class="row">
        <div class="col-md-12">
         <div class="form-group">
-         <label for="sbscsref-n">
+         <label>
           Have you been referred for smoking cessation
                                     services?
          </label>
@@ -600,7 +600,7 @@
        </div>
        <div id="sbfc-container" style="display: none;">
         <div class="form-group col-sm-4 col-md-2">
-         <label class="control-label" for="sbfcf-n">
+         <label class="control-label">
           Father?
          </label>
          <br/>
@@ -614,7 +614,7 @@
          </label>
         </div>
         <div class="form-group col-sm-4 col-md-2">
-         <label class="control-label" for="sbfcm-n">
+         <label class="control-label">
           Mother?
          </label>
          <br/>
@@ -628,7 +628,7 @@
          </label>
         </div>
         <div class="form-group col-sm-4 col-md-2">
-         <label class="control-label" for="sbfcs-n">
+         <label class="control-label">
           Siblings?
          </label>
          <br/>
@@ -902,7 +902,7 @@
        </div>
        <div class="col-sm-12 col-md-6 col-lg-7" id="sbmpa-container" style="display: none;">
         <div class="form-group">
-         <label for="sbmpat-n">
+         <label>
           Under current treatment?
          </label>
          <br/>
@@ -1022,7 +1022,7 @@
          <input class="form-control input-sm numeric" id="sbmpdw" maxlength="4" name="sbmpdw" size="4" type="text"/>
         </div>
         <div class=" col-sm-4 col-md-2 form-group">
-         <label class="control-label" for="sbmpdt-n">
+         <label class="control-label">
           Treated?
          </label>
          <br/>
@@ -1393,7 +1393,7 @@
        </div>
        <div id="sbmpht-container" style="display: none;">
         <div class="form-group col-sm-4 col-md-2" style="vertical-align: top;">
-         <label class="form-check-inline" for="sbmphtt-n">
+         <label class="form-check-inline">
           Treated?
          </label>
          <br/>
@@ -1652,7 +1652,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.05
+     2019.09.11
     </span>
    </div>
   </footer>

--- a/docs/mockups/biopsy.html
+++ b/docs/mockups/biopsy.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.05" name="version"/>
+  <meta content="2019.09.11" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Biopsy Form
@@ -806,7 +806,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.05
+     2019.09.11
     </span>
    </div>
   </footer>

--- a/docs/mockups/casereview.html
+++ b/docs/mockups/casereview.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.05" name="version"/>
+  <meta content="2019.09.11" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Case Review
@@ -251,7 +251,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.05
+     2019.09.11
     </span>
    </div>
   </footer>

--- a/docs/mockups/ctevaluation-elcap.html
+++ b/docs/mockups/ctevaluation-elcap.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.05" name="version"/>
+  <meta content="2019.09.11" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    CT Evaluation Form
@@ -268,7 +268,7 @@
      <div class="row">
       <div class="col-sm-12">
        <div class="form-group">
-        <label class="required" for="cetex-b">
+        <label class="required">
          Type of exam
         </label>
         <br/>
@@ -294,7 +294,7 @@
      </div>
      <div class="row">
       <div class="col-sm-12 form-group">
-       <label class="control-label required" for="cectp-l">
+       <label class="control-label required">
         CT protocol
        </label>
        <br/>
@@ -5562,7 +5562,7 @@
       </div>
      </div>
      <div class="form-group">
-      <label class="control-label" for="ceccv-n">
+      <label class="control-label">
        Coronary calcifications
       </label>
       <br/>
@@ -5798,7 +5798,7 @@
            <tbody>
             <tr>
              <td>
-              <label class="control-label" for="cecbc-n">
+              <label class="control-label">
                Cysts
               </label>
              </td>
@@ -5864,7 +5864,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cecbb-n">
+              <label class="control-label">
                Blebs/Bullae
               </label>
              </td>
@@ -5930,7 +5930,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cerdc-n">
+              <label class="control-label">
                Regional or diffuse
                                 consolidation
               </label>
@@ -6001,7 +6001,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cescr-n">
+              <label class="control-label">
                Scarring
               </label>
              </td>
@@ -6092,7 +6092,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cebrsb-n">
+              <label class="control-label">
                Bronchiectasis
               </label>
              </td>
@@ -6158,7 +6158,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cebrss-n">
+              <label class="control-label">
                Small airways disease
               </label>
              </td>
@@ -6224,7 +6224,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cebs-n">
+              <label class="control-label">
                Post-surgical findings
               </label>
               <br/>
@@ -6303,7 +6303,7 @@
            <tbody>
             <tr>
              <td>
-              <label class="control-label" for="cerb-n">
+              <label class="control-label">
                Traction bronchiectasis in a peripheral
                                 location
               </label>
@@ -6370,7 +6370,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cepgo-n">
+              <label class="control-label">
                Peripheral ground-glass opacities
               </label>
              </td>
@@ -6436,7 +6436,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="ceret-n">
+              <label class="control-label">
                Reticulations
               </label>
              </td>
@@ -6502,7 +6502,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cephc-n">
+              <label class="control-label">
                Honeycombing
               </label>
              </td>
@@ -6605,7 +6605,7 @@
            <tbody>
             <tr>
              <td>
-              <label class="control-label" for="cept-n">
+              <label class="control-label">
                Pleural thickening/plaques
               </label>
              </td>
@@ -6646,7 +6646,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cebatr-n">
+              <label class="control-label">
                Rounded atelectasis
               </label>
              </td>
@@ -6802,7 +6802,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cepu-n">
+              <label class="control-label">
                Pleural tumor
               </label>
              </td>
@@ -7002,7 +7002,7 @@
            <tbody>
             <tr>
              <td>
-              <label class="control-label" for="ceata-n">
+              <label class="control-label">
                Thyroid
               </label>
              </td>
@@ -7054,7 +7054,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="ceaya-n">
+              <label class="control-label">
                Thymus
               </label>
               <br/>
@@ -8217,7 +8217,7 @@
      </h3>
      <div class="row">
       <div class="col-sm-12 form-group">
-       <label class="required" for="cefpa-lr">
+       <label class="required">
         Follow-up approach:
        </label>
        <br/>
@@ -8241,7 +8241,7 @@
      </h4>
      <div class="row">
       <div class="col-sm-12 form-group">
-       <label for="cefuw-nw">
+       <label>
         LDCT follow-up:
        </label>
        <br/>
@@ -8585,7 +8585,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.05
+     2019.09.11
     </span>
    </div>
   </footer>

--- a/docs/mockups/ctevaluation.html
+++ b/docs/mockups/ctevaluation.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.05" name="version"/>
+  <meta content="2019.09.11" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    CT Evaluation Form
@@ -268,7 +268,7 @@
      <div class="row">
       <div class="col-sm-12">
        <div class="form-group">
-        <label class="required" for="cetex-b">
+        <label class="required">
          Type of exam
         </label>
         <br/>
@@ -294,7 +294,7 @@
      </div>
      <div class="row">
       <div class="col-sm-12 form-group">
-       <label class="control-label required" for="cectp-l">
+       <label class="control-label required">
         CT protocol
        </label>
        <br/>
@@ -5562,7 +5562,7 @@
       </div>
      </div>
      <div class="form-group">
-      <label class="control-label" for="ceccv-n">
+      <label class="control-label">
        Coronary calcifications
       </label>
       <br/>
@@ -5798,7 +5798,7 @@
            <tbody>
             <tr>
              <td>
-              <label class="control-label" for="cecbc-n">
+              <label class="control-label">
                Cysts
               </label>
              </td>
@@ -5864,7 +5864,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cecbb-n">
+              <label class="control-label">
                Blebs/Bullae
               </label>
              </td>
@@ -5930,7 +5930,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cerdc-n">
+              <label class="control-label">
                Regional or diffuse
                                 consolidation
               </label>
@@ -6001,7 +6001,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cescr-n">
+              <label class="control-label">
                Scarring
               </label>
              </td>
@@ -6092,7 +6092,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cebrsb-n">
+              <label class="control-label">
                Bronchiectasis
               </label>
              </td>
@@ -6158,7 +6158,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cebrss-n">
+              <label class="control-label">
                Small airways disease
               </label>
              </td>
@@ -6224,7 +6224,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cebs-n">
+              <label class="control-label">
                Post-surgical findings
               </label>
               <br/>
@@ -6303,7 +6303,7 @@
            <tbody>
             <tr>
              <td>
-              <label class="control-label" for="cerb-n">
+              <label class="control-label">
                Traction bronchiectasis in a peripheral
                                 location
               </label>
@@ -6370,7 +6370,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cepgo-n">
+              <label class="control-label">
                Peripheral ground-glass opacities
               </label>
              </td>
@@ -6436,7 +6436,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="ceret-n">
+              <label class="control-label">
                Reticulations
               </label>
              </td>
@@ -6502,7 +6502,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cephc-n">
+              <label class="control-label">
                Honeycombing
               </label>
              </td>
@@ -6605,7 +6605,7 @@
            <tbody>
             <tr>
              <td>
-              <label class="control-label" for="cept-n">
+              <label class="control-label">
                Pleural thickening/plaques
               </label>
              </td>
@@ -6646,7 +6646,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cebatr-n">
+              <label class="control-label">
                Rounded atelectasis
               </label>
              </td>
@@ -6802,7 +6802,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cepu-n">
+              <label class="control-label">
                Pleural tumor
               </label>
              </td>
@@ -7002,7 +7002,7 @@
            <tbody>
             <tr>
              <td>
-              <label class="control-label" for="ceata-n">
+              <label class="control-label">
                Thyroid
               </label>
              </td>
@@ -7054,7 +7054,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="ceaya-n">
+              <label class="control-label">
                Thymus
               </label>
               <br/>
@@ -8217,7 +8217,7 @@
      </h3>
      <div class="row">
       <div class="col-sm-12 form-group">
-       <label class="required" for="cefpa-lr">
+       <label class="required">
         Follow-up approach:
        </label>
        <br/>
@@ -8241,7 +8241,7 @@
      </h4>
      <div class="row">
       <div class="col-sm-12 form-group">
-       <label for="cefuw-nw">
+       <label>
         LDCT follow-up:
        </label>
        <br/>
@@ -8585,7 +8585,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.05
+     2019.09.11
     </span>
    </div>
   </footer>

--- a/docs/mockups/followup.html
+++ b/docs/mockups/followup.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.05" name="version"/>
+  <meta content="2019.09.11" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Followup Form
@@ -1252,7 +1252,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.05
+     2019.09.11
     </span>
    </div>
   </footer>

--- a/docs/mockups/home.html
+++ b/docs/mockups/home.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.05" name="version"/>
+  <meta content="2019.09.11" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Home
@@ -232,7 +232,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.05
+     2019.09.11
     </span>
    </div>
   </footer>

--- a/docs/mockups/intake.html
+++ b/docs/mockups/intake.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.05" name="version"/>
+  <meta content="2019.09.11" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Lung Screening and Surveillance Intake Form
@@ -1217,7 +1217,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.05
+     2019.09.11
     </span>
    </div>
   </footer>

--- a/docs/mockups/intervention.html
+++ b/docs/mockups/intervention.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.05" name="version"/>
+  <meta content="2019.09.11" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Intervention and Surgical Treatment Form
@@ -697,7 +697,7 @@
       <div class="row">
        <div class="col-sm-6 col-md-4">
         <div class="form-group">
-         <label for="sbahpft-n">
+         <label>
           Have you had a pulmonary function test?
          </label>
          <br/>
@@ -743,7 +743,7 @@
       <div class="row">
        <div class="col-sm-6 col-md-4">
         <div class="form-group form-inline">
-         <label for="rbmep-n">
+         <label>
           Was mediastinoscopy performed?
          </label>
          <br/>
@@ -837,7 +837,7 @@
       </h3>
       <div class="row">
        <div class="col-md-6">
-        <label class="required" for="rbrep-n">
+        <label class="required">
          Was resection performed?
         </label>
         <div class="form-group">
@@ -905,7 +905,7 @@
       </div>
       <div class="row">
        <div class="col-md-6">
-        <label for="rbtosv-v">
+        <label>
          Type of surgery
         </label>
         <div class="form-group form-inline">
@@ -950,7 +950,7 @@
       </div>
       <div class="row">
        <div class="col-md-6">
-        <label for="rbvto-n">
+        <label>
          Was there a conversion of VATS to open?
         </label>
         <div class="form-group form-inline">
@@ -1025,7 +1025,7 @@
         </div>
        </div>
        <div class="col-md-6">
-        <label for="rbrmm-g">
+        <label>
          Method of margin measurement:
         </label>
         <div class="form-group">
@@ -1042,7 +1042,7 @@
       </div>
       <div class="row">
        <div class="col-md-6">
-        <label for="rbwm-s">
+        <label>
          Which margin?
         </label>
         <div class="form-group form-inline">
@@ -1079,7 +1079,7 @@
       </div>
       <div class="row">
        <div class="col-md-6">
-        <label for="rbrmws-r">
+        <label>
          Margin measured with staples:
         </label>
         <div class="form-group">
@@ -1098,7 +1098,7 @@
         </div>
        </div>
        <div class="col-md-6">
-        <label for="rbrmam-n">
+        <label>
          If initial margin positive, was additional margin sent?
         </label>
         <div class="form-group">
@@ -1137,7 +1137,7 @@
       </div>
       <div class="row">
        <div class="col-md-3">
-        <label for="rbras-n">
+        <label>
          Additional surgery for same lesion?
         </label>
         <div class="form-group">
@@ -1181,7 +1181,7 @@
       </div>
       <div class="row">
        <div class="col-md-6">
-        <label for="rbrcs-n">
+        <label>
          Complications during surgery?
         </label>
         <div class="form-group">
@@ -1206,7 +1206,7 @@
       </div>
       <div class="row">
        <div class="col-md-6">
-        <label for="rbrch-n">
+        <label>
          Complications during hospital stay?
         </label>
         <div class="form-group">
@@ -1290,7 +1290,7 @@
       </div>
       <div class="row">
        <div class="col-md-4">
-        <label for="rbinv-n">
+        <label>
          Invasion of other structures
         </label>
         <div class="form-group form-inline">
@@ -1306,7 +1306,7 @@
        </div>
        <div class="col-md-2">
         <div class="form-group">
-         <label for="rbinv-v">
+         <label>
           Location
          </label>
          <div class="checkbox">
@@ -2428,7 +2428,7 @@
       <div class="row">
        <div class="col-md-4">
         <div class="form-group">
-         <label for="rbal-n">
+         <label>
           Additional lesions
          </label>
          <label class="radio-inline" for="rbal-n">
@@ -3461,7 +3461,7 @@
       </div>
       <div class="row">
        <div class="col-md-6 col-lg-4 form-group">
-        <label for="rtfor-d">
+        <label>
          Frequency of radiation
         </label>
         <br/>
@@ -3571,7 +3571,7 @@
       </div>
       <div class="row">
        <div class="col-lg-9 col-md-12 form-group">
-        <label for="rtrddt-3d">
+        <label>
          Radiation dose delivery
         </label>
         <br/>
@@ -3621,7 +3621,7 @@
       </div>
       <div class="row">
        <div class="col-lg-9 col-md-9 form-group">
-        <label for="rttmct-n">
+        <label>
          Tumor motion control
         </label>
         <br/>
@@ -3655,7 +3655,7 @@
       </div>
       <div class="row">
        <div class="col-md-12 form-group">
-        <label for="rtsbrt-n">
+        <label>
          <abbr title="Stereotactic Body Radiation Therapy">
           SBRT
          </abbr>
@@ -3673,7 +3673,7 @@
       </div>
       <div class="row">
        <div class="col-md-6 form-group">
-        <label for="rttmct-n">
+        <label>
          Patient positioning
         </label>
         <br/>
@@ -3699,7 +3699,7 @@
       </div>
       <div class="row">
        <div class="col-md-6 form-group">
-        <label for="rttmct-n">
+        <label>
          Treatment verification
         </label>
         <br/>
@@ -3869,7 +3869,7 @@
       </div>
       <div class="row">
        <div class="col-lg-3 col-md-4 form-group">
-        <label for="rtedds-n">
+        <label>
          Was the entire dose delivered to the patient?
         </label>
         <br/>
@@ -3892,7 +3892,7 @@
       <div class="row">
        <div class="col-md-4">
         <div class="form-group">
-         <label for="rtcui-n">
+         <label>
           Were there any unplanned interruptions or incomplete
                                     fractions?
          </label>
@@ -3919,7 +3919,7 @@
       <div class="row">
        <div class="col-md-4">
         <div class="form-group">
-         <label for="rtse-n">
+         <label>
           Side effects
          </label>
          <br/>
@@ -4109,7 +4109,7 @@
       <div class="row">
        <div class="col-lg-4 col-md-5">
         <div class="form-group">
-         <label for="sbahpft-n">
+         <label>
           Frequency of chemotherapy
          </label>
          <br/>
@@ -4214,7 +4214,7 @@
       <div class="row">
        <div class="col-md-4">
         <div class="form-group">
-         <label for="chedd-n">
+         <label>
           Was the entire dose delivered to the patient?
          </label>
          <br/>
@@ -4240,7 +4240,7 @@
       <div class="row">
        <div class="col-md-4">
         <div class="form-group">
-         <label for="chc-n">
+         <label>
           Were there complications associated with treatment?
          </label>
          <br/>
@@ -4266,7 +4266,7 @@
       <div class="row">
        <div class="col-md-4">
         <div class="form-group">
-         <label for="chse-n">
+         <label>
           Side effects
          </label>
          <br/>
@@ -9563,7 +9563,7 @@
       </div>
      </div>
      <div class="form-group">
-      <label class="control-label" for="ceccv-n">
+      <label class="control-label">
        Coronary calcifications
       </label>
       <br/>
@@ -9800,7 +9800,7 @@
            <tbody>
             <tr>
              <td>
-              <label class="control-label" for="cecbc-n">
+              <label class="control-label">
                Cysts
               </label>
              </td>
@@ -9866,7 +9866,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cecbb-n">
+              <label class="control-label">
                Blebs/Bullae
               </label>
              </td>
@@ -9932,7 +9932,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cerdc-n">
+              <label class="control-label">
                Regional or diffuse
                                 consolidation
               </label>
@@ -10003,7 +10003,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cescr-n">
+              <label class="control-label">
                Scarring
               </label>
              </td>
@@ -10094,7 +10094,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cebrsb-n">
+              <label class="control-label">
                Bronchiectasis
               </label>
              </td>
@@ -10160,7 +10160,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cebrss-n">
+              <label class="control-label">
                Small airways disease
               </label>
              </td>
@@ -10226,7 +10226,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cebs-n">
+              <label class="control-label">
                Post-surgical findings
               </label>
               <br/>
@@ -10305,7 +10305,7 @@
            <tbody>
             <tr>
              <td>
-              <label class="control-label" for="cerb-n">
+              <label class="control-label">
                Traction bronchiectasis in a peripheral
                                 location
               </label>
@@ -10372,7 +10372,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cepgo-n">
+              <label class="control-label">
                Peripheral ground-glass opacities
               </label>
              </td>
@@ -10438,7 +10438,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="ceret-n">
+              <label class="control-label">
                Reticulations
               </label>
              </td>
@@ -10504,7 +10504,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cephc-n">
+              <label class="control-label">
                Honeycombing
               </label>
              </td>
@@ -10607,7 +10607,7 @@
            <tbody>
             <tr>
              <td>
-              <label class="control-label" for="cept-n">
+              <label class="control-label">
                Pleural thickening/plaques
               </label>
              </td>
@@ -10648,7 +10648,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cebatr-n">
+              <label class="control-label">
                Rounded atelectasis
               </label>
              </td>
@@ -10804,7 +10804,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cepu-n">
+              <label class="control-label">
                Pleural tumor
               </label>
              </td>
@@ -11004,7 +11004,7 @@
            <tbody>
             <tr>
              <td>
-              <label class="control-label" for="ceata-n">
+              <label class="control-label">
                Thyroid
               </label>
              </td>
@@ -11056,7 +11056,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="ceaya-n">
+              <label class="control-label">
                Thymus
               </label>
               <br/>
@@ -12188,7 +12188,7 @@
      </h3>
      <div class="row">
       <div class="col-sm-12 form-group">
-       <label for="cefuw-nw">
+       <label>
         LDCT follow-up:
        </label>
        <br/>
@@ -12449,7 +12449,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.05
+     2019.09.11
     </span>
    </div>
   </footer>

--- a/docs/mockups/newform.html
+++ b/docs/mockups/newform.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.05" name="version"/>
+  <meta content="2019.09.11" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    New Form
@@ -196,7 +196,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.05
+     2019.09.11
     </span>
    </div>
   </footer>

--- a/docs/mockups/pet.html
+++ b/docs/mockups/pet.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.05" name="version"/>
+  <meta content="2019.09.11" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    PET Evaluation Form
@@ -1065,15 +1065,14 @@
     </h3>
     <div class="row">
      <div class="col-md-12 form-group">
-      <label class="required" for="ceimn-rs">
+      <label class="required">
        Nodules
       </label>
       <div class="radio">
        <label>
         <input id="ceimn-rs" name="ceimn" required="required" type="radio" value="rs"/>
         No evidence
-                            of
-                            abnormal uptake. Follow-up as recommended above.
+                            of abnormal uptake. Follow-up as recommended above.
        </label>
       </div>
       <div class="radio">
@@ -1094,7 +1093,7 @@
     </div>
     <div class="row">
      <div class="col-md-12 form-group">
-      <label class="required" for="ceimo-no">
+      <label class="required">
        Other findings
       </label>
       <div class="radio">
@@ -1187,7 +1186,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.05
+     2019.09.11
     </span>
    </div>
   </footer>
@@ -1303,8 +1302,7 @@
                                     let selector = "";
                                     if (e.element.id) {
                                         selector = "#" + e.element.id
-                                    }
-                                    else {
+                                    } else {
                                         selector = "[name=" + e.element.name + "]"
                                     }
 

--- a/docs/mockups/report.html
+++ b/docs/mockups/report.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.05" name="version"/>
+  <meta content="2019.09.11" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
   </title>
@@ -235,7 +235,7 @@ Interpreted by: IJL+DY
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.05
+     2019.09.11
     </span>
    </div>
   </footer>

--- a/docs/mockups/table.html
+++ b/docs/mockups/table.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.05" name="version"/>
+  <meta content="2019.09.11" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
   </title>
@@ -230,7 +230,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.05
+     2019.09.11
     </span>
    </div>
   </footer>

--- a/docs/mockups/toggler.html
+++ b/docs/mockups/toggler.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.05" name="version"/>
+  <meta content="2019.09.11" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
   </title>
@@ -175,7 +175,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.05
+     2019.09.11
     </span>
    </div>
   </footer>

--- a/docs/mockups/upload.html
+++ b/docs/mockups/upload.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.05" name="version"/>
+  <meta content="2019.09.11" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Upload New Patients
@@ -176,7 +176,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.05
+     2019.09.11
     </span>
    </div>
   </footer>

--- a/docs/src/_abnormalities.jinja2
+++ b/docs/src/_abnormalities.jinja2
@@ -30,7 +30,7 @@
                         <tbody>
                         {% set rf = ["rul","rml","rll","lul","lll"] %}
                         <tr>
-                            <td><label class="control-label" for="cecbc-n">Cysts</label></td>
+                            <td><label class="control-label">Cysts</label></td>
                             <td>
                                 <div class="form-group">
                                     {{ f.yesCheckbox("cecbc") }}
@@ -45,7 +45,7 @@
                             {% endfor %}
                         </tr>
                         <tr>
-                            <td><label class="control-label" for="cecbb-n">Blebs/Bullae</label></td>
+                            <td><label class="control-label">Blebs/Bullae</label></td>
                             <td>
                                 <div class="form-group">
                                     {{ f.yesCheckbox("cecbb") }}
@@ -60,7 +60,7 @@
                             {% endfor %}
                         </tr>
                         <tr>
-                            <td><label class="control-label" for="cerdc-n">Regional or diffuse
+                            <td><label class="control-label">Regional or diffuse
                                 consolidation</label><br/>
                                 <small>(focal - put in nodule grid)</small>
                             </td>
@@ -78,7 +78,7 @@
                             {% endfor %}
                         </tr>
                         <tr>
-                            <td><label class="control-label" for="cescr-n">Scarring</label></td>
+                            <td><label class="control-label">Scarring</label></td>
                             <td>
                                 <div class="form-group">
                                     {{ f.yesCheckbox("cescr") }}
@@ -104,8 +104,7 @@
                         </tr>
 
                         <tr>
-                            <td><label class="control-label"
-                                       for="cebrsb-n">Bronchiectasis</label></td>
+                            <td><label class="control-label">Bronchiectasis</label></td>
                             <td>
                                 <div class="form-group">
                                     {{ f.yesCheckbox("cebrsb") }}
@@ -121,7 +120,7 @@
                         </tr>
 
                         <tr>
-                            <td><label class="control-label" for="cebrss-n">Small airways disease</label></td>
+                            <td><label class="control-label" >Small airways disease</label></td>
                             <td>
                                 <div class="form-group">
                                     {{ f.yesCheckbox("cebrss") }}
@@ -137,7 +136,7 @@
                         </tr>
                         <tr>
                             <td>
-                                <label class="control-label" for="cebs-n">Post-surgical findings</label><br/>
+                                <label class="control-label">Post-surgical findings</label><br/>
                                 <small>(i.e. bronchial resection margin)</small>
                             </td>
                             <td>
@@ -174,7 +173,7 @@
                         </thead>
                         <tbody>
                         <tr>
-                            <td><label class="control-label" for="cerb-n">Traction bronchiectasis in a peripheral
+                            <td><label class="control-label" >Traction bronchiectasis in a peripheral
                                 location</label></td>
                             <td>
                                 <div class="form-group">
@@ -191,7 +190,7 @@
                         </tr>
 
                         <tr>
-                            <td><label class="control-label" for="cepgo-n">Peripheral ground-glass opacities</label>
+                            <td><label class="control-label">Peripheral ground-glass opacities</label>
                             </td>
                             <td>
                                 <div class="form-group">
@@ -208,7 +207,7 @@
                         </tr>
 
                         <tr>
-                            <td><label class="control-label" for="ceret-n">Reticulations</label></td>
+                            <td><label class="control-label" >Reticulations</label></td>
                             <td>
                                 <div class="form-group">
                                     {{ f.yesCheckbox("ceret") }}
@@ -224,7 +223,7 @@
                         </tr>
 
                         <tr>
-                            <td><label class="control-label" for="cephc-n">Honeycombing</label></td>
+                            <td><label class="control-label">Honeycombing</label></td>
                             <td>
                                 <div class="form-group">
                                     {{ f.yesCheckbox("cephc") }}
@@ -274,7 +273,7 @@
                         <tbody>
                         <tr>
                             <td>
-                                <label class="control-label" for="cept-n">Pleural thickening/plaques</label>
+                                <label class="control-label" >Pleural thickening/plaques</label>
                             </td>
                             <td>
                                 <div class="form-group">
@@ -293,7 +292,7 @@
                         </tr>
 
                         <tr>
-                            <td><label class="control-label" for="cebatr-n">Rounded atelectasis</label></td>
+                            <td><label class="control-label">Rounded atelectasis</label></td>
                             <td>
                                 <div class="form-group">
                                     {{ f.yesCheckbox("cebatr") }}
@@ -360,7 +359,7 @@
                         </tr>
 
                         <tr>
-                            <td><label class="control-label" for="cepu-n">Pleural tumor</label></td>
+                            <td><label class="control-label" >Pleural tumor</label></td>
                             <td colspan="6">
                                 <div class="form-group">
                                     {{ f.yesCheckbox("cepu") }}
@@ -510,7 +509,7 @@
                     <table class="table">
                         <tbody>
                         <tr>
-                            <td><label class="control-label" for="ceata-n">Thyroid</label></td>
+                            <td><label class="control-label">Thyroid</label></td>
                             <td>
                                 <div class="form-group">
                                     {{ f.yesCheckbox("ceata") }}
@@ -530,7 +529,7 @@
                         </tr>
 
                         <tr>
-                            <td><label class="control-label" for="ceaya-n">Thymus</label><br/>
+                            <td><label class="control-label" >Thymus</label><br/>
                                 <small>(report if ovoid &gt; 7 mm or if thymic shape with width &gt; 1.3cm)
                                 </small>
                             </td>

--- a/docs/src/_emphysema.jinja2
+++ b/docs/src/_emphysema.jinja2
@@ -18,8 +18,7 @@
     </div>
 </div>
 <div class="form-group">
-    <label class="control-label"
-           for="ceccv-n">Coronary calcifications</label><br/>
+    <label class="control-label">Coronary calcifications</label><br/>
     {{ f.inlineRadio("ceccv","ceccv-n","n","None") }}
     {{ f.inlineRadio("ceccv","ceccv-m","m","Mild") }}
     {{ f.inlineRadio("ceccv","ceccv-d","d","Moderate") }}

--- a/docs/src/_followup.jinja2
+++ b/docs/src/_followup.jinja2
@@ -14,7 +14,7 @@
     <div class="row">
         <div class="col-sm-12 form-group">
             {# NB: cefu prefix is used for follow-up options validator so not used here#}
-            <label for="cefpa-lr" class="required">Follow-up approach:</label><br/>
+            <label class="required">Follow-up approach:</label><br/>
             {{ f.inlineRadio("cefpa", "cefpa-lr", lungRadsApproachValue, "Lung-RADS", true) }}
             {{ f.inlineRadio("cefpa", "cefpa-el", elcapApproachValue, "I-ELCAP") }}
         </div>
@@ -33,7 +33,7 @@
 
 <div class="row">
     <div class="col-sm-12 form-group">
-        <label for="cefuw-nw">LDCT follow-up:</label><br/>
+        <label>LDCT follow-up:</label><br/>
         {{ f.inlineRadio("cefuw", "cefuw-1y", "1y", "Annual repeat") }}
         {{ f.inlineRadio("cefuw", "cefuw-nw", "nw", "Now") }}
         {{ f.inlineRadio("cefuw", "cefuw-1m", "1m", "1 month") }}

--- a/docs/src/background.html.jinja2
+++ b/docs/src/background.html.jinja2
@@ -23,7 +23,7 @@
 
             <div class="row">
                 <div class="col-sm-6 col-md-4">
-                    <label for="sbahao-i" class="control-label">Have you ever worked in any of the following?</label>
+                    <label class="control-label">Have you ever worked in any of the following?</label>
                 </div>
                 <div class="col-sm-6 col-md-8">
                     <div class="form-group">
@@ -48,7 +48,7 @@
 
             <div class="row">
                 <div class="col-sm-6 col-md-4 col-lg-4">
-                    <label for="sblcs-n">Have you experienced any symptoms indicative of lung cancer?</label>
+                    <label>Have you experienced any symptoms indicative of lung cancer?</label>
                 </div>
                 <div class="col-sm-6 col-md-3 col-lg-2">
                     <div class="form-group">
@@ -99,8 +99,8 @@
 
             <div class="row">
                 <div class="col-sm-6 col-md-4 col-lg-4">
-                    <label for="sbahpft-n" class="control-label">Have you had a pulmonary function test within the last
-                        five years?</label>
+                    <label class="control-label">Have you had a pulmonary function test within the last five
+                        years?</label>
                 </div>
                 <div class="col-sm-6 col-md-3 col-lg-2">
                     <div class="form-group">
@@ -145,7 +145,7 @@
 
             <div class="row">
                 <div class="col-sm-6 col-md-4 col-lg-4">
-                    <label for="sbscs-n" class="control-label">Have you been provided with smoking cessation
+                    <label class="control-label">Have you been provided with smoking cessation
                         services?</label>
                 </div>
                 <div class="col-sm-6 col-md-3 col-lg-2">
@@ -185,7 +185,7 @@
                     <div class="row">
                         <div class="col-md-12">
                             <div class="form-group">
-                                <label for="sbscs5a-n">Have you been counseled on the 5 A’s (Ask, Assess, Advise,
+                                <label>Have you been counseled on the 5 A’s (Ask, Assess, Advise,
                                     Assist, Arrange)?</label><br/>
                                 {{ f.inlineRadioNY("sbscs5a") }}
                             </div>
@@ -194,7 +194,7 @@
                     <div class="row">
                         <div class="col-md-12">
                             <div class="form-group">
-                                <label for="sbscsref-n">Have you been referred for smoking cessation
+                                <label>Have you been referred for smoking cessation
                                     services?</label><br/>
                                 {{ f.inlineRadioNY("sbscsref") }}
                             </div>
@@ -222,17 +222,17 @@
                         </div>
                         <div id="sbfc-container" style="display: none;">
                             <div class="form-group col-sm-4 col-md-2">
-                                <label class="control-label" for="sbfcf-n">Father?</label><br/>
+                                <label class="control-label">Father?</label><br/>
                                 {{ f.inlineRadio("sbfcf","sbfcf-n","n", "No") }}
                                 {{ f.inlineRadio("sbfcf","sbfcf-y","y", "Yes") }}
                             </div>
                             <div class="form-group col-sm-4 col-md-2">
-                                <label class="control-label" for="sbfcm-n">Mother?</label><br/>
+                                <label class="control-label">Mother?</label><br/>
                                 {{ f.inlineRadio("sbfcm","sbfcm-n","n", "No") }}
                                 {{ f.inlineRadio("sbfcm","sbfcm-y","y", "Yes") }}
                             </div>
                             <div class="form-group col-sm-4 col-md-2">
-                                <label class="control-label" for="sbfcs-n">Siblings?</label><br/>
+                                <label class="control-label">Siblings?</label><br/>
                                 {{ f.inlineRadio("sbfcs","sbfcs-n","n", "No") }}
                                 {{ f.inlineRadio("sbfcs","sbfcs-y","y", "Yes") }}
                             </div>
@@ -376,7 +376,7 @@
                         </div>
                         <div class="col-sm-12 col-md-6 col-lg-7" id="sbmpa-container" style="display: none;">
                             <div class="form-group">
-                                <label for="sbmpat-n">Under current treatment?</label><br/>
+                                <label>Under current treatment?</label><br/>
                                 {{ f.inlineRadio("sbmpat","sbmpat-n","n", "No") }}
                                 {{ f.inlineRadio("sbmpat","sbmpat-y","y", "Yes") }}
                             </div>
@@ -438,7 +438,7 @@
                             </div>
 
                             <div class=" col-sm-4 col-md-2 form-group">
-                                <label class="control-label" for="sbmpdt-n">Treated?</label><br/>
+                                <label class="control-label">Treated?</label><br/>
                                 {{ f.inlineRadio("sbmpdt", "sbmpdt-n", "n", "No") }}
                                 {{ f.inlineRadio("sbmpdt", "sbmpdt-y", "y", "Yes") }}
                             </div>
@@ -631,7 +631,7 @@
                         </div>
                         <div id="sbmpht-container" style="display: none;">
                             <div class="form-group col-sm-4 col-md-2" style="vertical-align: top;">
-                                <label class="form-check-inline" for="sbmphtt-n">Treated?</label><br/>
+                                <label class="form-check-inline">Treated?</label><br/>
                                 {{ f.inlineRadio("sbmphtt", "sbmphtt-n", "n", "No") }}
                                 {{ f.inlineRadio("sbmphtt", "sbmphtt-y", "y", "Yes") }}
                             </div>

--- a/docs/src/ctevaluation.html.jinja2
+++ b/docs/src/ctevaluation.html.jinja2
@@ -92,7 +92,7 @@
                 <div class="row">
                     <div class="col-sm-12">
                         <div class="form-group">
-                            <label for="cetex-b" class="required">Type of exam</label>
+                            <label class="required">Type of exam</label>
                             <br/>
                             <label class="radio-inline">
                                 <input type="radio" name="cetex" id="cetex" value="b" required="required">
@@ -117,7 +117,7 @@
 
                 <div class="row">
                     <div class="col-sm-12 form-group">
-                        <label for="cectp-l" class="control-label required">CT protocol</label>
+                        <label class="control-label required">CT protocol</label>
                         <br/>
                         <label class="radio-inline">
                             <input type="radio" name="cectp" id="cectp-l" value="l" required="required">

--- a/docs/src/intervention.html.jinja2
+++ b/docs/src/intervention.html.jinja2
@@ -322,7 +322,7 @@
                     <div class="row">
                         <div class="col-sm-6 col-md-4">
                             <div class="form-group">
-                                <label for="sbahpft-n">Have you had a pulmonary function test?</label>
+                                <label>Have you had a pulmonary function test?</label>
                                 <br/>
                                 {{ f.inlineRadioNY("sbahpft") }}
                             </div>
@@ -355,7 +355,7 @@
                     <div class="row">
                         <div class="col-sm-6 col-md-4">
                             <div class="form-group form-inline">
-                                <label for="rbmep-n">Was mediastinoscopy performed?</label>
+                                <label>Was mediastinoscopy performed?</label>
                                 <br/>
                                 {{ f.inlineRadioNY("rbmep") }}
                             </div>
@@ -415,7 +415,7 @@
                     <h3>Resection</h3>
                     <div class="row">
                         <div class="col-md-6">
-                            <label class="required" for="rbrep-n">Was resection performed?</label>
+                            <label class="required">Was resection performed?</label>
                             <div class="form-group">
                                 {{ f.inlineRadio("rbrep", "rbrep-n", "n", "No", true) }}
                                 {{ f.inlineRadio("rbrep", "rbrep-y", "y", "Yes") }}
@@ -451,7 +451,7 @@
 
                     <div class="row">
                         <div class="col-md-6">
-                            <label for="rbtosv-v">Type of surgery</label>
+                            <label>Type of surgery</label>
                             <div class="form-group form-inline">
                                 {{ f.checkbox( "rbtosv", "v", "VAT") }}
                                 {{ f.checkbox( "rbtost", "t", "Thoracotomy") }}
@@ -469,7 +469,7 @@
 
                     <div class="row">
                         <div class="col-md-6">
-                            <label for="rbvto-n">Was there a conversion of VATS to open?</label>
+                            <label>Was there a conversion of VATS to open?</label>
                             <div class="form-group form-inline">
                                 {{ f.inlineRadio("rbvto", "rbvto-n", "n", "No", true) }}
                                 {{ f.inlineRadio("rbvto", "rbvto-y", "y", "Yes", true) }}
@@ -516,7 +516,7 @@
                             </div>
                         </div>
                         <div class="col-md-6">
-                            <label for="rbrmm-g">Method of margin measurement:</label>
+                            <label>Method of margin measurement:</label>
                             <div class="form-group">
                                 {{ f.inlineRadio("rbrmm", "rbrmm-g", "g", "Gross", true) }}
                                 {{ f.inlineRadio("rbrmm", "rbrmm-m", "m", "Micro", true) }}
@@ -526,7 +526,7 @@
 
                     <div class="row">
                         <div class="col-md-6">
-                            <label for="rbwm-s">Which margin?</label>
+                            <label>Which margin?</label>
                             <div class="form-group form-inline">
                                 {{ f.inlineRadio("rbwm", "rbwm-s", "s", "Staple Line", true) }}
                                 {{ f.inlineRadio("rbwm", "rbwm-b", "b", "Bronchial", true) }}
@@ -545,7 +545,7 @@
 
                     <div class="row">
                         <div class="col-md-6">
-                            <label for="rbrmws-r">Margin measured with staples:</label>
+                            <label>Margin measured with staples:</label>
                             <div class="form-group">
                                 {{ f.inlineRadio("rbrmws", "rbrmws-r", "r", "Removed", true) }}
                                 {{ f.inlineRadio("rbrmws", "rbrmws-i", "i", "Intact", true) }}
@@ -553,7 +553,7 @@
                             </div>
                         </div>
                         <div class="col-md-6">
-                            <label for="rbrmam-n">If initial margin positive, was additional margin sent?</label>
+                            <label>If initial margin positive, was additional margin sent?</label>
                             <div class="form-group">
                                 {{ f.inlineRadio("rbrmam", "rbrmam-n", "n", "No", true) }}
                                 {{ f.inlineRadio("rbrmam", "rbrmam-y", "y", "Yes", true) }}
@@ -579,7 +579,7 @@
 
                     <div class="row">
                         <div class="col-md-3">
-                            <label for="rbras-n">Additional surgery for same lesion?</label>
+                            <label>Additional surgery for same lesion?</label>
                             <div class="form-group">
                                 {{ f.inlineRadio("rbras", "rbras-n", "n", "No", true) }}
                                 {{ f.inlineRadio("rbras", "rbras-y", "y", "Yes", true) }}
@@ -601,7 +601,7 @@
 
                     <div class="row">
                         <div class="col-md-6">
-                            <label for="rbrcs-n">Complications during surgery?</label>
+                            <label>Complications during surgery?</label>
                             <div class="form-group">
                                 {{ f.inlineRadio("rbrcs", "rbrcs-n", "n", "No", true) }}
                                 {{ f.inlineRadio("rbrcs", "rbrcs-y", "y", "Yes", true) }}
@@ -617,7 +617,7 @@
 
                     <div class="row">
                         <div class="col-md-6">
-                            <label for="rbrch-n">Complications during hospital stay?</label>
+                            <label>Complications during hospital stay?</label>
                             <div class="form-group">
                                 {{ f.inlineRadio("rbrch", "rbrch-n", "n", "No", true) }}
                                 {{ f.inlineRadio("rbrch", "rbrch-y", "y", "Yes", true) }}
@@ -669,7 +669,7 @@
 
                     <div class="row">
                         <div class="col-md-4">
-                            <label for="rbinv-n">Invasion of other structures</label>
+                            <label>Invasion of other structures</label>
                             <div class="form-group form-inline">
                                 {{ f.inlineRadio("rbinv", "rbinv-n", "n", "No", true) }}
                                 {{ f.inlineRadio("rbinv", "rbinv-y", "y", "Yes", true) }}
@@ -677,7 +677,7 @@
                         </div>
                         <div class="col-md-2">
                             <div class="form-group">
-                                <label for="rbinv-v">Location</label>
+                                <label>Location</label>
                                 {{ f.checkbox("rbinvv","v", "Major vascular") }}
                                 {{ f.checkbox("rbinvp","p", "Pleura") }}
                                 {{ f.checkbox("rbinva","a", "Angiolymphatic") }}
@@ -1153,7 +1153,7 @@
                     <div class="row">
                         <div class="col-md-4">
                             <div class="form-group">
-                                <label for="rbal-n">Additional lesions</label>
+                                <label>Additional lesions</label>
                                 {{ f.inlineRadioNY("rbal") }}
                             </div>
                         </div>
@@ -1458,7 +1458,7 @@
                     </div>
                     <div class="row">
                         <div class="col-md-6 col-lg-4 form-group">
-                            <label for="rtfor-d">Frequency of radiation</label><br/>
+                            <label>Frequency of radiation</label><br/>
                             {{ f.inlineRadio("rtfor","rtfor-d","d","daily") }}
                             {{ f.inlineRadio("rtfor","rtfor-od","od","every other day") }}
                             {{ f.inlineRadio("rtfor","rtfor-w","w","weekly") }}
@@ -1518,7 +1518,7 @@
 
                     <div class="row">
                         <div class="col-lg-9 col-md-12 form-group">
-                            <label for="rtrddt-3d">Radiation dose delivery</label>
+                            <label>Radiation dose delivery</label>
                             <br/>
                             {{ f.inlineRadio("rtrddt", "rtrddt-3d", "crt", "3D-CRT") }}
                             {{ f.inlineRadio("rtrddt", "rtrddt-imrt", "imrt", "<abbr title=\"Intensity-modulated radiotherapy\">IMRT</abbr>") }}
@@ -1536,7 +1536,7 @@
                     </div>
                     <div class="row">
                         <div class="col-lg-9 col-md-9 form-group">
-                            <label for="rttmct-n">Tumor motion control</label>
+                            <label>Tumor motion control</label>
                             <br/>
                             {{ f.inlineRadio("rttmct", "rttmct-n", "n", "none") }}
                             {{ f.inlineRadio("rttmct", "rttmct-s", "s", "4D-simulation and ITV") }}
@@ -1551,14 +1551,14 @@
                     </div>
                     <div class="row">
                         <div class="col-md-12 form-group">
-                            <label for="rtsbrt-n"><abbr title="Stereotactic Body Radiation Therapy">SBRT</abbr></label>
+                            <label><abbr title="Stereotactic Body Radiation Therapy">SBRT</abbr></label>
                             <br/>
                             {{ f.inlineRadioNY("rtsbrt") }}
                         </div>
                     </div>
                     <div class="row">
                         <div class="col-md-6 form-group">
-                            <label for="rttmct-n">Patient positioning</label>
+                            <label>Patient positioning</label>
                             <br/>
                             {{ f.inlineRadio("rtpp", "rtpp-a", "a", "alphacradle") }}
                             {{ f.inlineRadio("rtpp", "rtpp-s", "s", "stereotactic body frame") }}
@@ -1571,7 +1571,7 @@
                     </div>
                     <div class="row">
                         <div class="col-md-6 form-group">
-                            <label for="rttmct-n">Treatment verification</label>
+                            <label>Treatment verification</label>
                             <br/>
                             {{ f.inlineRadio("rttv", "rttv-i", "i", "kv images") }}
                             {{ f.inlineRadio("rttv", "rttv-c", "c", "cone beam CT") }}
@@ -1698,7 +1698,7 @@
                     </div>
                     <div class="row">
                         <div class="col-lg-3 col-md-4 form-group">
-                            <label for="rtedds-n">Was the entire dose delivered to the patient?</label>
+                            <label>Was the entire dose delivered to the patient?</label>
                             <br/>
                             {{ f.inlineRadioNY("rtedd") }}
                         </div>
@@ -1711,7 +1711,7 @@
                     <div class="row">
                         <div class="col-md-4">
                             <div class="form-group">
-                                <label for="rtcui-n">Were there any unplanned interruptions or incomplete
+                                <label>Were there any unplanned interruptions or incomplete
                                     fractions?</label>
                                 <br/>
                                 {{ f.inlineRadioNY("rtcui") }}
@@ -1728,7 +1728,7 @@
                     <div class="row">
                         <div class="col-md-4">
                             <div class="form-group">
-                                <label for="rtse-n">Side effects</label>
+                                <label>Side effects</label>
                                 <br/>
                                 {{ f.inlineRadio("rtse", "rtse-n", "n", "none") }}
                                 {{ f.inlineRadio("rtse", "rtse-mi", "mi", "minimal") }}
@@ -1813,7 +1813,7 @@
                     <div class="row">
                         <div class="col-lg-4 col-md-5">
                             <div class="form-group">
-                                <label for="sbahpft-n">Frequency of chemotherapy</label>
+                                <label>Frequency of chemotherapy</label>
                                 <br/>
                                 {{ f.inlineRadio("chf", "chf-d", "d", "daily") }}
                                 {{ f.inlineRadio("chf", "chf-od", "od", "every other day") }}
@@ -1871,7 +1871,7 @@
                     <div class="row">
                         <div class="col-md-4">
                             <div class="form-group">
-                                <label for="chedd-n">Was the entire dose delivered to the patient?</label>
+                                <label>Was the entire dose delivered to the patient?</label>
                                 <br/>
                                 {{ f.inlineRadioNY("chedd") }}
                             </div>
@@ -1886,7 +1886,7 @@
                     <div class="row">
                         <div class="col-md-4">
                             <div class="form-group">
-                                <label for="chc-n">Were there complications associated with treatment?</label>
+                                <label>Were there complications associated with treatment?</label>
                                 <br/>
                                 {{ f.inlineRadioNY("chc") }}
                             </div>
@@ -1901,7 +1901,7 @@
                     <div class="row">
                         <div class="col-md-4">
                             <div class="form-group">
-                                <label for="chse-n">Side effects</label>
+                                <label>Side effects</label>
                                 <br/>
                                 {{ f.inlineRadio("chse", "chse-n", "n", "none") }}
                                 {{ f.inlineRadio("chse", "chse-mi", "mi", "minimal") }}

--- a/docs/src/pet.html.jinja2
+++ b/docs/src/pet.html.jinja2
@@ -427,12 +427,11 @@
             <h3>Impression</h3>
             <div class="row">
                 <div class="col-md-12 form-group">
-                    <label class="required" for="ceimn-rs">Nodules</label>
+                    <label class="required">Nodules</label>
                     <div class="radio">
                         <label>
                             <input type="radio" name="ceimn" id="ceimn-rs" value="rs" required="required"> No evidence
-                            of
-                            abnormal uptake. Follow-up as recommended above.
+                            of abnormal uptake. Follow-up as recommended above.
                         </label>
                     </div>
                     <div class="radio">
@@ -452,7 +451,7 @@
             </div>
             <div class="row">
                 <div class="col-md-12 form-group">
-                    <label class="required" for="ceimo-no">Other findings</label>
+                    <label class="required">Other findings</label>
                     <div class="radio">
                         <label>
                             <input type="radio" name="ceimo" id="ceimo-rs" value="rs" required="required"> No other
@@ -493,7 +492,7 @@
         </form>
     </div>
 
-    {{ f.deleteFormModal("pet.html", mockup, formMethod)}}
+    {{ f.deleteFormModal("pet.html", mockup, formMethod) }}
 {% endblock %}
 
 {% block script %}
@@ -552,8 +551,7 @@
                                     let selector = "";
                                     if (e.element.id) {
                                         selector = "#" + e.element.id
-                                    }
-                                    else {
+                                    } else {
                                         selector = "[name=" + e.element.name + "]"
                                     }
 

--- a/docs/www/background.html
+++ b/docs/www/background.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.05" name="version"/>
+  <meta content="2019.09.11" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Background Form
@@ -161,7 +161,7 @@
     </h3>
     <div class="row">
      <div class="col-sm-6 col-md-4">
-      <label class="control-label" for="sbahao-i">
+      <label class="control-label">
        Have you ever worked in any of the following?
       </label>
      </div>
@@ -254,7 +254,7 @@
     <hr class="visible-xs-block visible-sm-block"/>
     <div class="row">
      <div class="col-sm-6 col-md-4 col-lg-4">
-      <label for="sblcs-n">
+      <label>
        Have you experienced any symptoms indicative of lung cancer?
       </label>
      </div>
@@ -358,9 +358,9 @@
     <hr class="visible-xs-block visible-sm-block"/>
     <div class="row">
      <div class="col-sm-6 col-md-4 col-lg-4">
-      <label class="control-label" for="sbahpft-n">
-       Have you had a pulmonary function test within the last
-                        five years?
+      <label class="control-label">
+       Have you had a pulmonary function test within the last five
+                        years?
       </label>
      </div>
      <div class="col-sm-6 col-md-3 col-lg-2">
@@ -421,7 +421,7 @@
     <hr class="visible-xs-block visible-sm-block"/>
     <div class="row">
      <div class="col-sm-6 col-md-4 col-lg-4">
-      <label class="control-label" for="sbscs-n">
+      <label class="control-label">
        Have you been provided with smoking cessation
                         services?
       </label>
@@ -525,7 +525,7 @@
       <div class="row">
        <div class="col-md-12">
         <div class="form-group">
-         <label for="sbscs5a-n">
+         <label>
           Have you been counseled on the 5 A’s (Ask, Assess, Advise,
                                     Assist, Arrange)?
          </label>
@@ -544,7 +544,7 @@
       <div class="row">
        <div class="col-md-12">
         <div class="form-group">
-         <label for="sbscsref-n">
+         <label>
           Have you been referred for smoking cessation
                                     services?
          </label>
@@ -600,7 +600,7 @@
        </div>
        <div id="sbfc-container" style="display: none;">
         <div class="form-group col-sm-4 col-md-2">
-         <label class="control-label" for="sbfcf-n">
+         <label class="control-label">
           Father?
          </label>
          <br/>
@@ -614,7 +614,7 @@
          </label>
         </div>
         <div class="form-group col-sm-4 col-md-2">
-         <label class="control-label" for="sbfcm-n">
+         <label class="control-label">
           Mother?
          </label>
          <br/>
@@ -628,7 +628,7 @@
          </label>
         </div>
         <div class="form-group col-sm-4 col-md-2">
-         <label class="control-label" for="sbfcs-n">
+         <label class="control-label">
           Siblings?
          </label>
          <br/>
@@ -902,7 +902,7 @@
        </div>
        <div class="col-sm-12 col-md-6 col-lg-7" id="sbmpa-container" style="display: none;">
         <div class="form-group">
-         <label for="sbmpat-n">
+         <label>
           Under current treatment?
          </label>
          <br/>
@@ -1022,7 +1022,7 @@
          <input class="form-control input-sm numeric" id="sbmpdw" maxlength="4" name="sbmpdw" size="4" type="text"/>
         </div>
         <div class=" col-sm-4 col-md-2 form-group">
-         <label class="control-label" for="sbmpdt-n">
+         <label class="control-label">
           Treated?
          </label>
          <br/>
@@ -1393,7 +1393,7 @@
        </div>
        <div id="sbmpht-container" style="display: none;">
         <div class="form-group col-sm-4 col-md-2" style="vertical-align: top;">
-         <label class="form-check-inline" for="sbmphtt-n">
+         <label class="form-check-inline">
           Treated?
          </label>
          <br/>
@@ -1652,7 +1652,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.05
+     2019.09.11
     </span>
    </div>
   </footer>

--- a/docs/www/biopsy.html
+++ b/docs/www/biopsy.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.05" name="version"/>
+  <meta content="2019.09.11" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Biopsy Form
@@ -806,7 +806,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.05
+     2019.09.11
     </span>
    </div>
   </footer>

--- a/docs/www/casereview.html
+++ b/docs/www/casereview.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.05" name="version"/>
+  <meta content="2019.09.11" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Case Review
@@ -179,7 +179,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.05
+     2019.09.11
     </span>
    </div>
   </footer>

--- a/docs/www/ctevaluation-elcap.html
+++ b/docs/www/ctevaluation-elcap.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.05" name="version"/>
+  <meta content="2019.09.11" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    CT Evaluation Form
@@ -268,7 +268,7 @@
      <div class="row">
       <div class="col-sm-12">
        <div class="form-group">
-        <label class="required" for="cetex-b">
+        <label class="required">
          Type of exam
         </label>
         <br/>
@@ -294,7 +294,7 @@
      </div>
      <div class="row">
       <div class="col-sm-12 form-group">
-       <label class="control-label required" for="cectp-l">
+       <label class="control-label required">
         CT protocol
        </label>
        <br/>
@@ -5562,7 +5562,7 @@
       </div>
      </div>
      <div class="form-group">
-      <label class="control-label" for="ceccv-n">
+      <label class="control-label">
        Coronary calcifications
       </label>
       <br/>
@@ -5798,7 +5798,7 @@
            <tbody>
             <tr>
              <td>
-              <label class="control-label" for="cecbc-n">
+              <label class="control-label">
                Cysts
               </label>
              </td>
@@ -5864,7 +5864,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cecbb-n">
+              <label class="control-label">
                Blebs/Bullae
               </label>
              </td>
@@ -5930,7 +5930,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cerdc-n">
+              <label class="control-label">
                Regional or diffuse
                                 consolidation
               </label>
@@ -6001,7 +6001,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cescr-n">
+              <label class="control-label">
                Scarring
               </label>
              </td>
@@ -6092,7 +6092,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cebrsb-n">
+              <label class="control-label">
                Bronchiectasis
               </label>
              </td>
@@ -6158,7 +6158,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cebrss-n">
+              <label class="control-label">
                Small airways disease
               </label>
              </td>
@@ -6224,7 +6224,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cebs-n">
+              <label class="control-label">
                Post-surgical findings
               </label>
               <br/>
@@ -6303,7 +6303,7 @@
            <tbody>
             <tr>
              <td>
-              <label class="control-label" for="cerb-n">
+              <label class="control-label">
                Traction bronchiectasis in a peripheral
                                 location
               </label>
@@ -6370,7 +6370,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cepgo-n">
+              <label class="control-label">
                Peripheral ground-glass opacities
               </label>
              </td>
@@ -6436,7 +6436,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="ceret-n">
+              <label class="control-label">
                Reticulations
               </label>
              </td>
@@ -6502,7 +6502,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cephc-n">
+              <label class="control-label">
                Honeycombing
               </label>
              </td>
@@ -6605,7 +6605,7 @@
            <tbody>
             <tr>
              <td>
-              <label class="control-label" for="cept-n">
+              <label class="control-label">
                Pleural thickening/plaques
               </label>
              </td>
@@ -6646,7 +6646,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cebatr-n">
+              <label class="control-label">
                Rounded atelectasis
               </label>
              </td>
@@ -6802,7 +6802,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cepu-n">
+              <label class="control-label">
                Pleural tumor
               </label>
              </td>
@@ -7002,7 +7002,7 @@
            <tbody>
             <tr>
              <td>
-              <label class="control-label" for="ceata-n">
+              <label class="control-label">
                Thyroid
               </label>
              </td>
@@ -7054,7 +7054,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="ceaya-n">
+              <label class="control-label">
                Thymus
               </label>
               <br/>
@@ -8217,7 +8217,7 @@
      </h3>
      <div class="row">
       <div class="col-sm-12 form-group">
-       <label class="required" for="cefpa-lr">
+       <label class="required">
         Follow-up approach:
        </label>
        <br/>
@@ -8241,7 +8241,7 @@
      </h4>
      <div class="row">
       <div class="col-sm-12 form-group">
-       <label for="cefuw-nw">
+       <label>
         LDCT follow-up:
        </label>
        <br/>
@@ -8585,7 +8585,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.05
+     2019.09.11
     </span>
    </div>
   </footer>

--- a/docs/www/ctevaluation.html
+++ b/docs/www/ctevaluation.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.05" name="version"/>
+  <meta content="2019.09.11" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    CT Evaluation Form
@@ -268,7 +268,7 @@
      <div class="row">
       <div class="col-sm-12">
        <div class="form-group">
-        <label class="required" for="cetex-b">
+        <label class="required">
          Type of exam
         </label>
         <br/>
@@ -294,7 +294,7 @@
      </div>
      <div class="row">
       <div class="col-sm-12 form-group">
-       <label class="control-label required" for="cectp-l">
+       <label class="control-label required">
         CT protocol
        </label>
        <br/>
@@ -5562,7 +5562,7 @@
       </div>
      </div>
      <div class="form-group">
-      <label class="control-label" for="ceccv-n">
+      <label class="control-label">
        Coronary calcifications
       </label>
       <br/>
@@ -5798,7 +5798,7 @@
            <tbody>
             <tr>
              <td>
-              <label class="control-label" for="cecbc-n">
+              <label class="control-label">
                Cysts
               </label>
              </td>
@@ -5864,7 +5864,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cecbb-n">
+              <label class="control-label">
                Blebs/Bullae
               </label>
              </td>
@@ -5930,7 +5930,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cerdc-n">
+              <label class="control-label">
                Regional or diffuse
                                 consolidation
               </label>
@@ -6001,7 +6001,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cescr-n">
+              <label class="control-label">
                Scarring
               </label>
              </td>
@@ -6092,7 +6092,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cebrsb-n">
+              <label class="control-label">
                Bronchiectasis
               </label>
              </td>
@@ -6158,7 +6158,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cebrss-n">
+              <label class="control-label">
                Small airways disease
               </label>
              </td>
@@ -6224,7 +6224,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cebs-n">
+              <label class="control-label">
                Post-surgical findings
               </label>
               <br/>
@@ -6303,7 +6303,7 @@
            <tbody>
             <tr>
              <td>
-              <label class="control-label" for="cerb-n">
+              <label class="control-label">
                Traction bronchiectasis in a peripheral
                                 location
               </label>
@@ -6370,7 +6370,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cepgo-n">
+              <label class="control-label">
                Peripheral ground-glass opacities
               </label>
              </td>
@@ -6436,7 +6436,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="ceret-n">
+              <label class="control-label">
                Reticulations
               </label>
              </td>
@@ -6502,7 +6502,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cephc-n">
+              <label class="control-label">
                Honeycombing
               </label>
              </td>
@@ -6605,7 +6605,7 @@
            <tbody>
             <tr>
              <td>
-              <label class="control-label" for="cept-n">
+              <label class="control-label">
                Pleural thickening/plaques
               </label>
              </td>
@@ -6646,7 +6646,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cebatr-n">
+              <label class="control-label">
                Rounded atelectasis
               </label>
              </td>
@@ -6802,7 +6802,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cepu-n">
+              <label class="control-label">
                Pleural tumor
               </label>
              </td>
@@ -7002,7 +7002,7 @@
            <tbody>
             <tr>
              <td>
-              <label class="control-label" for="ceata-n">
+              <label class="control-label">
                Thyroid
               </label>
              </td>
@@ -7054,7 +7054,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="ceaya-n">
+              <label class="control-label">
                Thymus
               </label>
               <br/>
@@ -8217,7 +8217,7 @@
      </h3>
      <div class="row">
       <div class="col-sm-12 form-group">
-       <label class="required" for="cefpa-lr">
+       <label class="required">
         Follow-up approach:
        </label>
        <br/>
@@ -8241,7 +8241,7 @@
      </h4>
      <div class="row">
       <div class="col-sm-12 form-group">
-       <label for="cefuw-nw">
+       <label>
         LDCT follow-up:
        </label>
        <br/>
@@ -8585,7 +8585,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.05
+     2019.09.11
     </span>
    </div>
   </footer>

--- a/docs/www/followup.html
+++ b/docs/www/followup.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.05" name="version"/>
+  <meta content="2019.09.11" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Followup Form
@@ -1252,7 +1252,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.05
+     2019.09.11
     </span>
    </div>
   </footer>

--- a/docs/www/home.html
+++ b/docs/www/home.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.05" name="version"/>
+  <meta content="2019.09.11" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Home
@@ -232,7 +232,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.05
+     2019.09.11
     </span>
    </div>
   </footer>

--- a/docs/www/intake.html
+++ b/docs/www/intake.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.05" name="version"/>
+  <meta content="2019.09.11" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Lung Screening and Surveillance Intake Form
@@ -1217,7 +1217,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.05
+     2019.09.11
     </span>
    </div>
   </footer>

--- a/docs/www/intervention.html
+++ b/docs/www/intervention.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.05" name="version"/>
+  <meta content="2019.09.11" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Intervention and Surgical Treatment Form
@@ -697,7 +697,7 @@
       <div class="row">
        <div class="col-sm-6 col-md-4">
         <div class="form-group">
-         <label for="sbahpft-n">
+         <label>
           Have you had a pulmonary function test?
          </label>
          <br/>
@@ -743,7 +743,7 @@
       <div class="row">
        <div class="col-sm-6 col-md-4">
         <div class="form-group form-inline">
-         <label for="rbmep-n">
+         <label>
           Was mediastinoscopy performed?
          </label>
          <br/>
@@ -837,7 +837,7 @@
       </h3>
       <div class="row">
        <div class="col-md-6">
-        <label class="required" for="rbrep-n">
+        <label class="required">
          Was resection performed?
         </label>
         <div class="form-group">
@@ -905,7 +905,7 @@
       </div>
       <div class="row">
        <div class="col-md-6">
-        <label for="rbtosv-v">
+        <label>
          Type of surgery
         </label>
         <div class="form-group form-inline">
@@ -950,7 +950,7 @@
       </div>
       <div class="row">
        <div class="col-md-6">
-        <label for="rbvto-n">
+        <label>
          Was there a conversion of VATS to open?
         </label>
         <div class="form-group form-inline">
@@ -1025,7 +1025,7 @@
         </div>
        </div>
        <div class="col-md-6">
-        <label for="rbrmm-g">
+        <label>
          Method of margin measurement:
         </label>
         <div class="form-group">
@@ -1042,7 +1042,7 @@
       </div>
       <div class="row">
        <div class="col-md-6">
-        <label for="rbwm-s">
+        <label>
          Which margin?
         </label>
         <div class="form-group form-inline">
@@ -1079,7 +1079,7 @@
       </div>
       <div class="row">
        <div class="col-md-6">
-        <label for="rbrmws-r">
+        <label>
          Margin measured with staples:
         </label>
         <div class="form-group">
@@ -1098,7 +1098,7 @@
         </div>
        </div>
        <div class="col-md-6">
-        <label for="rbrmam-n">
+        <label>
          If initial margin positive, was additional margin sent?
         </label>
         <div class="form-group">
@@ -1137,7 +1137,7 @@
       </div>
       <div class="row">
        <div class="col-md-3">
-        <label for="rbras-n">
+        <label>
          Additional surgery for same lesion?
         </label>
         <div class="form-group">
@@ -1181,7 +1181,7 @@
       </div>
       <div class="row">
        <div class="col-md-6">
-        <label for="rbrcs-n">
+        <label>
          Complications during surgery?
         </label>
         <div class="form-group">
@@ -1206,7 +1206,7 @@
       </div>
       <div class="row">
        <div class="col-md-6">
-        <label for="rbrch-n">
+        <label>
          Complications during hospital stay?
         </label>
         <div class="form-group">
@@ -1290,7 +1290,7 @@
       </div>
       <div class="row">
        <div class="col-md-4">
-        <label for="rbinv-n">
+        <label>
          Invasion of other structures
         </label>
         <div class="form-group form-inline">
@@ -1306,7 +1306,7 @@
        </div>
        <div class="col-md-2">
         <div class="form-group">
-         <label for="rbinv-v">
+         <label>
           Location
          </label>
          <div class="checkbox">
@@ -2428,7 +2428,7 @@
       <div class="row">
        <div class="col-md-4">
         <div class="form-group">
-         <label for="rbal-n">
+         <label>
           Additional lesions
          </label>
          <label class="radio-inline" for="rbal-n">
@@ -3461,7 +3461,7 @@
       </div>
       <div class="row">
        <div class="col-md-6 col-lg-4 form-group">
-        <label for="rtfor-d">
+        <label>
          Frequency of radiation
         </label>
         <br/>
@@ -3571,7 +3571,7 @@
       </div>
       <div class="row">
        <div class="col-lg-9 col-md-12 form-group">
-        <label for="rtrddt-3d">
+        <label>
          Radiation dose delivery
         </label>
         <br/>
@@ -3621,7 +3621,7 @@
       </div>
       <div class="row">
        <div class="col-lg-9 col-md-9 form-group">
-        <label for="rttmct-n">
+        <label>
          Tumor motion control
         </label>
         <br/>
@@ -3655,7 +3655,7 @@
       </div>
       <div class="row">
        <div class="col-md-12 form-group">
-        <label for="rtsbrt-n">
+        <label>
          <abbr title="Stereotactic Body Radiation Therapy">
           SBRT
          </abbr>
@@ -3673,7 +3673,7 @@
       </div>
       <div class="row">
        <div class="col-md-6 form-group">
-        <label for="rttmct-n">
+        <label>
          Patient positioning
         </label>
         <br/>
@@ -3699,7 +3699,7 @@
       </div>
       <div class="row">
        <div class="col-md-6 form-group">
-        <label for="rttmct-n">
+        <label>
          Treatment verification
         </label>
         <br/>
@@ -3869,7 +3869,7 @@
       </div>
       <div class="row">
        <div class="col-lg-3 col-md-4 form-group">
-        <label for="rtedds-n">
+        <label>
          Was the entire dose delivered to the patient?
         </label>
         <br/>
@@ -3892,7 +3892,7 @@
       <div class="row">
        <div class="col-md-4">
         <div class="form-group">
-         <label for="rtcui-n">
+         <label>
           Were there any unplanned interruptions or incomplete
                                     fractions?
          </label>
@@ -3919,7 +3919,7 @@
       <div class="row">
        <div class="col-md-4">
         <div class="form-group">
-         <label for="rtse-n">
+         <label>
           Side effects
          </label>
          <br/>
@@ -4109,7 +4109,7 @@
       <div class="row">
        <div class="col-lg-4 col-md-5">
         <div class="form-group">
-         <label for="sbahpft-n">
+         <label>
           Frequency of chemotherapy
          </label>
          <br/>
@@ -4214,7 +4214,7 @@
       <div class="row">
        <div class="col-md-4">
         <div class="form-group">
-         <label for="chedd-n">
+         <label>
           Was the entire dose delivered to the patient?
          </label>
          <br/>
@@ -4240,7 +4240,7 @@
       <div class="row">
        <div class="col-md-4">
         <div class="form-group">
-         <label for="chc-n">
+         <label>
           Were there complications associated with treatment?
          </label>
          <br/>
@@ -4266,7 +4266,7 @@
       <div class="row">
        <div class="col-md-4">
         <div class="form-group">
-         <label for="chse-n">
+         <label>
           Side effects
          </label>
          <br/>
@@ -9563,7 +9563,7 @@
       </div>
      </div>
      <div class="form-group">
-      <label class="control-label" for="ceccv-n">
+      <label class="control-label">
        Coronary calcifications
       </label>
       <br/>
@@ -9800,7 +9800,7 @@
            <tbody>
             <tr>
              <td>
-              <label class="control-label" for="cecbc-n">
+              <label class="control-label">
                Cysts
               </label>
              </td>
@@ -9866,7 +9866,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cecbb-n">
+              <label class="control-label">
                Blebs/Bullae
               </label>
              </td>
@@ -9932,7 +9932,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cerdc-n">
+              <label class="control-label">
                Regional or diffuse
                                 consolidation
               </label>
@@ -10003,7 +10003,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cescr-n">
+              <label class="control-label">
                Scarring
               </label>
              </td>
@@ -10094,7 +10094,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cebrsb-n">
+              <label class="control-label">
                Bronchiectasis
               </label>
              </td>
@@ -10160,7 +10160,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cebrss-n">
+              <label class="control-label">
                Small airways disease
               </label>
              </td>
@@ -10226,7 +10226,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cebs-n">
+              <label class="control-label">
                Post-surgical findings
               </label>
               <br/>
@@ -10305,7 +10305,7 @@
            <tbody>
             <tr>
              <td>
-              <label class="control-label" for="cerb-n">
+              <label class="control-label">
                Traction bronchiectasis in a peripheral
                                 location
               </label>
@@ -10372,7 +10372,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cepgo-n">
+              <label class="control-label">
                Peripheral ground-glass opacities
               </label>
              </td>
@@ -10438,7 +10438,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="ceret-n">
+              <label class="control-label">
                Reticulations
               </label>
              </td>
@@ -10504,7 +10504,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cephc-n">
+              <label class="control-label">
                Honeycombing
               </label>
              </td>
@@ -10607,7 +10607,7 @@
            <tbody>
             <tr>
              <td>
-              <label class="control-label" for="cept-n">
+              <label class="control-label">
                Pleural thickening/plaques
               </label>
              </td>
@@ -10648,7 +10648,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cebatr-n">
+              <label class="control-label">
                Rounded atelectasis
               </label>
              </td>
@@ -10804,7 +10804,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="cepu-n">
+              <label class="control-label">
                Pleural tumor
               </label>
              </td>
@@ -11004,7 +11004,7 @@
            <tbody>
             <tr>
              <td>
-              <label class="control-label" for="ceata-n">
+              <label class="control-label">
                Thyroid
               </label>
              </td>
@@ -11056,7 +11056,7 @@
             </tr>
             <tr>
              <td>
-              <label class="control-label" for="ceaya-n">
+              <label class="control-label">
                Thymus
               </label>
               <br/>
@@ -12188,7 +12188,7 @@
      </h3>
      <div class="row">
       <div class="col-sm-12 form-group">
-       <label for="cefuw-nw">
+       <label>
         LDCT follow-up:
        </label>
        <br/>
@@ -12449,7 +12449,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.05
+     2019.09.11
     </span>
    </div>
   </footer>

--- a/docs/www/newform.html
+++ b/docs/www/newform.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.05" name="version"/>
+  <meta content="2019.09.11" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    New Form
@@ -196,7 +196,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.05
+     2019.09.11
     </span>
    </div>
   </footer>

--- a/docs/www/pet.html
+++ b/docs/www/pet.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.05" name="version"/>
+  <meta content="2019.09.11" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    PET Evaluation Form
@@ -1065,15 +1065,14 @@
     </h3>
     <div class="row">
      <div class="col-md-12 form-group">
-      <label class="required" for="ceimn-rs">
+      <label class="required">
        Nodules
       </label>
       <div class="radio">
        <label>
         <input id="ceimn-rs" name="ceimn" required="required" type="radio" value="rs"/>
         No evidence
-                            of
-                            abnormal uptake. Follow-up as recommended above.
+                            of abnormal uptake. Follow-up as recommended above.
        </label>
       </div>
       <div class="radio">
@@ -1094,7 +1093,7 @@
     </div>
     <div class="row">
      <div class="col-md-12 form-group">
-      <label class="required" for="ceimo-no">
+      <label class="required">
        Other findings
       </label>
       <div class="radio">
@@ -1187,7 +1186,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.05
+     2019.09.11
     </span>
    </div>
   </footer>
@@ -1303,8 +1302,7 @@
                                     let selector = "";
                                     if (e.element.id) {
                                         selector = "#" + e.element.id
-                                    }
-                                    else {
+                                    } else {
                                         selector = "[name=" + e.element.name + "]"
                                     }
 

--- a/docs/www/report.html
+++ b/docs/www/report.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.05" name="version"/>
+  <meta content="2019.09.11" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
   </title>
@@ -173,7 +173,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.05
+     2019.09.11
     </span>
    </div>
   </footer>

--- a/docs/www/table.html
+++ b/docs/www/table.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.05" name="version"/>
+  <meta content="2019.09.11" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
   </title>
@@ -222,7 +222,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.05
+     2019.09.11
     </span>
    </div>
   </footer>

--- a/docs/www/toggler.html
+++ b/docs/www/toggler.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.05" name="version"/>
+  <meta content="2019.09.11" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
   </title>
@@ -175,7 +175,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.05
+     2019.09.11
     </span>
    </div>
   </footer>

--- a/docs/www/upload.html
+++ b/docs/www/upload.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.05" name="version"/>
+  <meta content="2019.09.11" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Upload New Patients
@@ -176,7 +176,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.05
+     2019.09.11
     </span>
    </div>
   </footer>


### PR DESCRIPTION
Per the Jira task, the previous behavior was unexpected where clicking on a question selected the first option for radio/checkbox options. To fix this, the `for` attribute was removed from applicable labels. 