### PR TITLE
VAP-457 remove thorax

### DIFF
--- a/docs/form-fields/intake.tsv
+++ b/docs/form-fields/intake.tsv
@@ -65,8 +65,8 @@ FIELD NUM	QUESTION	NAME	TYPE	REQUIRED	PLACEHOLDER	VALUES	LABELS
 64	Smoking cessation education provided	sicep	textarea	0			Smoking cessation education provided
 65	Lung CA Dx (if applicable): Date	sicadx	text	0			MM/DD/YYYY
 66	Lung CA Dx (if applicable): Location if not in VA	sicadxl	text	0			Location if not in VA
-67	Any prior thorax CT: Date	siptct	text	0			MM/DD/YYYY
-68	Any prior thorax CT: Location if not in VA	siptctl	text	0			Location if not in VA
+67	Any prior CT: Date	siptct	text	0			MM/DD/YYYY
+68	Any prior CT: Location if not in VA	siptctl	text	0			Location if not in VA
 69	Informed decision making discussion complete	siidmdc	checkbox	1		1	Informed decision making discussion complete
 70	Based on this information, the Veteran has opted to	sildct	radio	1		n;l;y	Not enroll;Not enroll at this time -- okay to contact in the future;Enroll in the Lung Screening program and have an LDCT ordered. Coordination of care will be made by the LSS team
 71	Clinical Indications for Initial Screening CT	siclin	textarea	0			Clinical Indications for Initial Screening CT

--- a/docs/mockups/background.html
+++ b/docs/mockups/background.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.26" name="version"/>
+  <meta content="2019.09.30" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Background Form
@@ -1652,7 +1652,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.26
+     2019.09.30
     </span>
    </div>
   </footer>

--- a/docs/mockups/background.html
+++ b/docs/mockups/background.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Background Form
@@ -1652,7 +1652,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/mockups/background.html
+++ b/docs/mockups/background.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Background Form
@@ -1639,7 +1639,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/mockups/biopsy.html
+++ b/docs/mockups/biopsy.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.26" name="version"/>
+  <meta content="2019.09.30" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Biopsy Form
@@ -806,7 +806,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.26
+     2019.09.30
     </span>
    </div>
   </footer>

--- a/docs/mockups/biopsy.html
+++ b/docs/mockups/biopsy.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Biopsy Form
@@ -803,7 +803,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/mockups/biopsy.html
+++ b/docs/mockups/biopsy.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Biopsy Form
@@ -806,7 +806,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/mockups/casereview.html
+++ b/docs/mockups/casereview.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Case Review
@@ -248,7 +248,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/mockups/casereview.html
+++ b/docs/mockups/casereview.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.26" name="version"/>
+  <meta content="2019.09.30" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Case Review
@@ -251,7 +251,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.26
+     2019.09.30
     </span>
    </div>
   </footer>

--- a/docs/mockups/casereview.html
+++ b/docs/mockups/casereview.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Case Review
@@ -251,7 +251,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/mockups/ctevaluation-elcap.html
+++ b/docs/mockups/ctevaluation-elcap.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.26" name="version"/>
+  <meta content="2019.09.30" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    CT Evaluation Form
@@ -8585,7 +8585,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.26
+     2019.09.30
     </span>
    </div>
   </footer>

--- a/docs/mockups/ctevaluation-elcap.html
+++ b/docs/mockups/ctevaluation-elcap.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    CT Evaluation Form
@@ -8585,7 +8585,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/mockups/ctevaluation-elcap.html
+++ b/docs/mockups/ctevaluation-elcap.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    CT Evaluation Form
@@ -8582,7 +8582,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/mockups/ctevaluation.html
+++ b/docs/mockups/ctevaluation.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.26" name="version"/>
+  <meta content="2019.09.30" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    CT Evaluation Form
@@ -8585,7 +8585,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.26
+     2019.09.30
     </span>
    </div>
   </footer>

--- a/docs/mockups/ctevaluation.html
+++ b/docs/mockups/ctevaluation.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    CT Evaluation Form
@@ -8585,7 +8585,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/mockups/ctevaluation.html
+++ b/docs/mockups/ctevaluation.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    CT Evaluation Form
@@ -8582,7 +8582,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/mockups/followup.html
+++ b/docs/mockups/followup.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Followup Form
@@ -1248,7 +1248,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/mockups/followup.html
+++ b/docs/mockups/followup.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Followup Form
@@ -1245,7 +1245,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/mockups/followup.html
+++ b/docs/mockups/followup.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.26" name="version"/>
+  <meta content="2019.09.30" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Followup Form
@@ -1248,7 +1248,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.26
+     2019.09.30
     </span>
    </div>
   </footer>

--- a/docs/mockups/home.html
+++ b/docs/mockups/home.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Home
@@ -229,7 +229,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/mockups/home.html
+++ b/docs/mockups/home.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.26" name="version"/>
+  <meta content="2019.09.30" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Home
@@ -232,7 +232,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.26
+     2019.09.30
     </span>
    </div>
   </footer>

--- a/docs/mockups/home.html
+++ b/docs/mockups/home.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Home
@@ -232,7 +232,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/mockups/intake.html
+++ b/docs/mockups/intake.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Lung Screening and Surveillance Intake Form
@@ -1074,7 +1074,7 @@
       </div>
       <div class="col-md-4 form-group">
        <label class="aria-hidden" for="siptctl">
-        Location throax CT
+        Location CT
        </label>
        <input class="form-control" id="siptctl" name="siptctl" type="text"/>
        <span class="help-block">
@@ -1345,7 +1345,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/mockups/intake.html
+++ b/docs/mockups/intake.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.26" name="version"/>
+  <meta content="2019.09.30" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Lung Screening and Surveillance Intake Form
@@ -1052,10 +1052,10 @@
      <div class="row form-group">
       <div class="col-md-4">
        <label class="visible-xs visible-sm" for="siptct">
-        Any prior thorax CT
+        Any prior CT
        </label>
        <label class="text-right pull-right hidden-xs hidden-sm" for="siptct">
-        Any prior thorax CT
+        Any prior CT
        </label>
       </div>
       <div class="col-md-4">
@@ -1345,7 +1345,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.26
+     2019.09.30
     </span>
    </div>
   </footer>

--- a/docs/mockups/intake.html
+++ b/docs/mockups/intake.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Lung Screening and Surveillance Intake Form
@@ -1049,10 +1049,10 @@
      <div class="row form-group">
       <div class="col-md-4">
        <label class="visible-xs visible-sm" for="siptct">
-        Any prior thorax CT
+        Any prior CT
        </label>
        <label class="text-right pull-right hidden-xs hidden-sm" for="siptct">
-        Any prior thorax CT
+        Any prior CT
        </label>
       </div>
       <div class="col-md-4">
@@ -1071,7 +1071,7 @@
       </div>
       <div class="col-md-4 form-group">
        <label class="aria-hidden" for="siptctl">
-        Location throax CT
+        Location CT
        </label>
        <input class="form-control" id="siptctl" name="siptctl" type="text"/>
        <span class="help-block">
@@ -1342,7 +1342,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/mockups/intervention.html
+++ b/docs/mockups/intervention.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Intervention and Surgical Treatment Form
@@ -12449,7 +12449,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/mockups/intervention.html
+++ b/docs/mockups/intervention.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.26" name="version"/>
+  <meta content="2019.09.30" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Intervention and Surgical Treatment Form
@@ -12449,7 +12449,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.26
+     2019.09.30
     </span>
    </div>
   </footer>

--- a/docs/mockups/intervention.html
+++ b/docs/mockups/intervention.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Intervention and Surgical Treatment Form
@@ -12446,7 +12446,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/mockups/newform.html
+++ b/docs/mockups/newform.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    New Form
@@ -196,7 +196,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/mockups/newform.html
+++ b/docs/mockups/newform.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.26" name="version"/>
+  <meta content="2019.09.30" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    New Form
@@ -196,7 +196,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.26
+     2019.09.30
     </span>
    </div>
   </footer>

--- a/docs/mockups/newform.html
+++ b/docs/mockups/newform.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    New Form
@@ -193,7 +193,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/mockups/pet.html
+++ b/docs/mockups/pet.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    PET Evaluation Form
@@ -1183,7 +1183,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/mockups/pet.html
+++ b/docs/mockups/pet.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.26" name="version"/>
+  <meta content="2019.09.30" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    PET Evaluation Form
@@ -1186,7 +1186,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.26
+     2019.09.30
     </span>
    </div>
   </footer>

--- a/docs/mockups/pet.html
+++ b/docs/mockups/pet.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    PET Evaluation Form
@@ -1186,7 +1186,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/mockups/report.html
+++ b/docs/mockups/report.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
   </title>
@@ -235,7 +235,7 @@ Interpreted by: IJL+DY
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/mockups/report.html
+++ b/docs/mockups/report.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
   </title>
@@ -232,7 +232,7 @@ Interpreted by: IJL+DY
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/mockups/report.html
+++ b/docs/mockups/report.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.26" name="version"/>
+  <meta content="2019.09.30" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
   </title>
@@ -235,7 +235,7 @@ Interpreted by: IJL+DY
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.26
+     2019.09.30
     </span>
    </div>
   </footer>

--- a/docs/mockups/table.html
+++ b/docs/mockups/table.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
   </title>
@@ -230,7 +230,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/mockups/table.html
+++ b/docs/mockups/table.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.26" name="version"/>
+  <meta content="2019.09.30" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
   </title>
@@ -230,7 +230,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.26
+     2019.09.30
     </span>
    </div>
   </footer>

--- a/docs/mockups/table.html
+++ b/docs/mockups/table.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
   </title>
@@ -227,7 +227,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/mockups/toggler.html
+++ b/docs/mockups/toggler.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
   </title>
@@ -175,7 +175,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/mockups/toggler.html
+++ b/docs/mockups/toggler.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.26" name="version"/>
+  <meta content="2019.09.30" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
   </title>
@@ -175,7 +175,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.26
+     2019.09.30
     </span>
    </div>
   </footer>

--- a/docs/mockups/toggler.html
+++ b/docs/mockups/toggler.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
   </title>
@@ -172,7 +172,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/mockups/upload.html
+++ b/docs/mockups/upload.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Upload New Patients
@@ -173,7 +173,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/mockups/upload.html
+++ b/docs/mockups/upload.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Upload New Patients
@@ -176,7 +176,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/mockups/upload.html
+++ b/docs/mockups/upload.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.26" name="version"/>
+  <meta content="2019.09.30" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Upload New Patients
@@ -176,7 +176,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.26
+     2019.09.30
     </span>
    </div>
   </footer>

--- a/docs/src/intake.html.jinja2
+++ b/docs/src/intake.html.jinja2
@@ -388,7 +388,7 @@
                     {{ f.datepicker ("siptct", "past") }}
                 </div>
                 <div class="col-md-4 form-group">
-                    <label class="aria-hidden" for="siptctl">Location throax CT</label>
+                    <label class="aria-hidden" for="siptctl">Location CT</label>
                     <input class="form-control" type="text" name="siptctl" id="siptctl"/>
                     <span class="help-block">Location if not in VA</span>
                 </div>

--- a/docs/src/intake.html.jinja2
+++ b/docs/src/intake.html.jinja2
@@ -382,7 +382,7 @@
             </div>
             <div class="row form-group">
                 <div class="col-md-4">
-                    {{ f.floatingLabel('siptct', 'Any prior thorax CT') }}
+                    {{ f.floatingLabel('siptct', 'Any prior CT') }}
                 </div>
                 <div class="col-md-4">
                     {{ f.datepicker ("siptct", "past") }}

--- a/docs/www/background.html
+++ b/docs/www/background.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.26" name="version"/>
+  <meta content="2019.09.30" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Background Form
@@ -1652,7 +1652,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.26
+     2019.09.30
     </span>
    </div>
   </footer>

--- a/docs/www/background.html
+++ b/docs/www/background.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Background Form
@@ -1652,7 +1652,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/www/background.html
+++ b/docs/www/background.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Background Form
@@ -1639,7 +1639,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/www/biopsy.html
+++ b/docs/www/biopsy.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.26" name="version"/>
+  <meta content="2019.09.30" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Biopsy Form
@@ -806,7 +806,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.26
+     2019.09.30
     </span>
    </div>
   </footer>

--- a/docs/www/biopsy.html
+++ b/docs/www/biopsy.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Biopsy Form
@@ -803,7 +803,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/www/biopsy.html
+++ b/docs/www/biopsy.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Biopsy Form
@@ -806,7 +806,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/www/casereview.html
+++ b/docs/www/casereview.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.26" name="version"/>
+  <meta content="2019.09.30" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Case Review
@@ -179,7 +179,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.26
+     2019.09.30
     </span>
    </div>
   </footer>

--- a/docs/www/casereview.html
+++ b/docs/www/casereview.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Case Review
@@ -176,7 +176,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/www/casereview.html
+++ b/docs/www/casereview.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Case Review
@@ -179,7 +179,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/www/ctevaluation-elcap.html
+++ b/docs/www/ctevaluation-elcap.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.26" name="version"/>
+  <meta content="2019.09.30" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    CT Evaluation Form
@@ -8585,7 +8585,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.26
+     2019.09.30
     </span>
    </div>
   </footer>

--- a/docs/www/ctevaluation-elcap.html
+++ b/docs/www/ctevaluation-elcap.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    CT Evaluation Form
@@ -8585,7 +8585,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/www/ctevaluation-elcap.html
+++ b/docs/www/ctevaluation-elcap.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    CT Evaluation Form
@@ -8582,7 +8582,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/www/ctevaluation.html
+++ b/docs/www/ctevaluation.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.26" name="version"/>
+  <meta content="2019.09.30" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    CT Evaluation Form
@@ -8585,7 +8585,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.26
+     2019.09.30
     </span>
    </div>
   </footer>

--- a/docs/www/ctevaluation.html
+++ b/docs/www/ctevaluation.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    CT Evaluation Form
@@ -8585,7 +8585,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/www/ctevaluation.html
+++ b/docs/www/ctevaluation.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    CT Evaluation Form
@@ -8582,7 +8582,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/www/followup.html
+++ b/docs/www/followup.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Followup Form
@@ -1203,7 +1203,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/www/followup.html
+++ b/docs/www/followup.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.26" name="version"/>
+  <meta content="2019.09.30" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Followup Form
@@ -1206,7 +1206,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.26
+     2019.09.30
     </span>
    </div>
   </footer>

--- a/docs/www/followup.html
+++ b/docs/www/followup.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Followup Form
@@ -1206,7 +1206,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/www/home.html
+++ b/docs/www/home.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Home
@@ -229,7 +229,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/www/home.html
+++ b/docs/www/home.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.26" name="version"/>
+  <meta content="2019.09.30" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Home
@@ -232,7 +232,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.26
+     2019.09.30
     </span>
    </div>
   </footer>

--- a/docs/www/home.html
+++ b/docs/www/home.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Home
@@ -232,7 +232,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/www/intake.html
+++ b/docs/www/intake.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Lung Screening and Surveillance Intake Form
@@ -1007,10 +1007,10 @@
      <div class="row form-group">
       <div class="col-md-4">
        <label class="visible-xs visible-sm" for="siptct">
-        Any prior thorax CT
+        Any prior CT
        </label>
        <label class="text-right pull-right hidden-xs hidden-sm" for="siptct">
-        Any prior thorax CT
+        Any prior CT
        </label>
       </div>
       <div class="col-md-4">
@@ -1029,7 +1029,7 @@
       </div>
       <div class="col-md-4 form-group">
        <label class="aria-hidden" for="siptctl">
-        Location throax CT
+        Location CT
        </label>
        <input class="form-control" id="siptctl" name="siptctl" type="text"/>
        <span class="help-block">
@@ -1300,7 +1300,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/www/intake.html
+++ b/docs/www/intake.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Lung Screening and Surveillance Intake Form
@@ -1032,7 +1032,7 @@
       </div>
       <div class="col-md-4 form-group">
        <label class="aria-hidden" for="siptctl">
-        Location throax CT
+        Location CT
        </label>
        <input class="form-control" id="siptctl" name="siptctl" type="text"/>
        <span class="help-block">
@@ -1303,7 +1303,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/www/intake.html
+++ b/docs/www/intake.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.26" name="version"/>
+  <meta content="2019.09.30" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Lung Screening and Surveillance Intake Form
@@ -1010,10 +1010,10 @@
      <div class="row form-group">
       <div class="col-md-4">
        <label class="visible-xs visible-sm" for="siptct">
-        Any prior thorax CT
+        Any prior CT
        </label>
        <label class="text-right pull-right hidden-xs hidden-sm" for="siptct">
-        Any prior thorax CT
+        Any prior CT
        </label>
       </div>
       <div class="col-md-4">
@@ -1303,7 +1303,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.26
+     2019.09.30
     </span>
    </div>
   </footer>

--- a/docs/www/intervention.html
+++ b/docs/www/intervention.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Intervention and Surgical Treatment Form
@@ -12449,7 +12449,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/www/intervention.html
+++ b/docs/www/intervention.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.26" name="version"/>
+  <meta content="2019.09.30" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Intervention and Surgical Treatment Form
@@ -12449,7 +12449,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.26
+     2019.09.30
     </span>
    </div>
   </footer>

--- a/docs/www/intervention.html
+++ b/docs/www/intervention.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Intervention and Surgical Treatment Form
@@ -12446,7 +12446,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/www/newform.html
+++ b/docs/www/newform.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    New Form
@@ -196,7 +196,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/www/newform.html
+++ b/docs/www/newform.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.26" name="version"/>
+  <meta content="2019.09.30" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    New Form
@@ -196,7 +196,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.26
+     2019.09.30
     </span>
    </div>
   </footer>

--- a/docs/www/newform.html
+++ b/docs/www/newform.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    New Form
@@ -193,7 +193,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/www/pet.html
+++ b/docs/www/pet.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    PET Evaluation Form
@@ -1183,7 +1183,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/www/pet.html
+++ b/docs/www/pet.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.26" name="version"/>
+  <meta content="2019.09.30" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    PET Evaluation Form
@@ -1186,7 +1186,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.26
+     2019.09.30
     </span>
    </div>
   </footer>

--- a/docs/www/pet.html
+++ b/docs/www/pet.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    PET Evaluation Form
@@ -1186,7 +1186,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/www/report.html
+++ b/docs/www/report.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
   </title>
@@ -173,7 +173,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/www/report.html
+++ b/docs/www/report.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
   </title>
@@ -170,7 +170,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/www/report.html
+++ b/docs/www/report.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.26" name="version"/>
+  <meta content="2019.09.30" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
   </title>
@@ -173,7 +173,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.26
+     2019.09.30
     </span>
    </div>
   </footer>

--- a/docs/www/table.html
+++ b/docs/www/table.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
   </title>
@@ -219,7 +219,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/www/table.html
+++ b/docs/www/table.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.26" name="version"/>
+  <meta content="2019.09.30" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
   </title>
@@ -222,7 +222,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.26
+     2019.09.30
     </span>
    </div>
   </footer>

--- a/docs/www/table.html
+++ b/docs/www/table.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
   </title>
@@ -222,7 +222,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/www/toggler.html
+++ b/docs/www/toggler.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
   </title>
@@ -175,7 +175,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/www/toggler.html
+++ b/docs/www/toggler.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.26" name="version"/>
+  <meta content="2019.09.30" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
   </title>
@@ -175,7 +175,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.26
+     2019.09.30
     </span>
    </div>
   </footer>

--- a/docs/www/toggler.html
+++ b/docs/www/toggler.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
   </title>
@@ -172,7 +172,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/www/upload.html
+++ b/docs/www/upload.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Upload New Patients
@@ -173,7 +173,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/www/upload.html
+++ b/docs/www/upload.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.30" name="version"/>
+  <meta content="2019.10.01" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Upload New Patients
@@ -176,7 +176,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.30
+     2019.10.01
     </span>
    </div>
   </footer>

--- a/docs/www/upload.html
+++ b/docs/www/upload.html
@@ -3,7 +3,7 @@
  <head>
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
-  <meta content="2019.09.26" name="version"/>
+  <meta content="2019.09.30" name="version"/>
   <meta content="Domenic DiNatale, domenic.dinatale@paraxialtech.com" name="author"/>
   <title>
    Upload New Patients
@@ -176,7 +176,7 @@
     <span id="sami-version" style="float:right; font-family: Courier,monospace">
      <span id="formMode">
      </span>
-     2019.09.26
+     2019.09.30
     </span>
    </div>
   </footer>

--- a/routines/SAMINOT1.m
+++ b/routines/SAMINOT1.m
@@ -325,8 +325,8 @@ INNOTE(vals,dest,cnt) ;
  ;[If a location not in the VA is specified show the next line]
  ;Location where prior lung cancer diagnosis was made: [Location Text]
  ;
- ;[If Any Prior Thorax CT Date is entered show the following 1 to 2 lines]
- ;Prior thorax CT:                   [Date]
+ ;[If Any Prior CT Date is entered show the following 1 to 2 lines]
+ ;Prior CT:                   [Date]
  ;[If a location not in the VA is specified show the next line]
  ;Location where prior lung cancer diagnosis was made: [Location Text]
  ;
@@ -390,9 +390,9 @@ INNOTE(vals,dest,cnt) ;
  . . d OUT("Location where prior lung cancer diagnosis was made:")
  . . d OUT("    "_$$XVAL("sicadxl",vals))
  i $$XVAL("siptct",vals)'="" d
- . d OUT("Prior thorax CT: "_$$XVAL("siptct",vals))
+ . d OUT("Prior CT: "_$$XVAL("siptct",vals))
  . i $$XVAL("siptctl",vals)'="" d  ;
- . . d OUT("Location where prior thorax CT was made:")
+ . . d OUT("Location where prior CT was made:")
  . . d OUT("    "_$$XVAL("siptctl",vals))
  d OUT(" ")
  d OUT("Shared Decision Making: ")


### PR DESCRIPTION
This PR removes the word "thorax" from the intake form as well as the intake note. There were a couple other places in M code where "throrax" was found, but was left untouched. @glilly should review those before merging this PR.